### PR TITLE
Added "eventLink" to events

### DIFF
--- a/components/Events.vue
+++ b/components/Events.vue
@@ -23,7 +23,7 @@
             We use * to specifically and intentionally include cis and trans women,
             as well as non-binary, agender, intersex people.
           </p>
-          <a :href="item.learnMoreLink" target="_blank" class="learnMoreButton">
+          <a :href="item.learnMoreLink || item.eventLink" target="_blank" class="learnMoreButton">
             <img class="learnMoreImage" src="../assets/sprite/svg/LearnMoreButton.svg" alt="">
           </a>
         </div>


### PR DESCRIPTION
The fields in firebase are inconsistent between lhd and nwplus. Namely, the text is "text" in nwplus and "blurb" in lhd. These fields should be consistent so that they can be edited with the cms. We should also add "eventLink" and "signupLink" fields
