### PR TITLE
change default email to info@nwplus.io

### DIFF
--- a/components/Outro.vue
+++ b/components/Outro.vue
@@ -3,8 +3,8 @@
     <p>
       nwPlus is always looking for new ventures, opportunities, and connections. If you are interested in working with us, joining us or speaking at one of our events, feel free to reach out to us at
       <a
-        href="mailto:hello@nwplus.io"
-      >hello@nwplus.io</a>.
+        href="mailto:info@nwplus.io"
+      >info@nwplus.io</a>.
     </p>
   </div>
 </template>


### PR DESCRIPTION
## :construction_worker: Changes

A brief summary of what changes were introduced.
- Changed default "reach us" email of nwplus

## :thought_balloon: Notes

Any additional things to take into consideration.
It wouldn't hurt anyone to change this. At worst if they finally figure out how to get access to hello@nwplus.io then info@nwplus.io can just forward email to that account

## :flashlight: Testing Instructions

Explain how to test your changes, if applicable.
Just click on the link and check out the text.
